### PR TITLE
Add testing setup for React app

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders welcome message', () => {
+  render(<App />);
+  const header = screen.getByText(/Welcome to Bento Order/i);
+  expect(header).toBeInTheDocument();
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add basic test for `App` component
- configure jest-dom in `setupTests`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3afb1b40832890062da7a9df0355