### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Bento Order
 
 これはReactテンプレートを使った初期アプリケーションです。`npm install`で依存関係をインストールし、`npm start`で開発サーバーを起動できます。
+
+## GitHub Pages へのデプロイ
+
+1. `npm install` で依存パッケージをインストールします。
+2. `npm run deploy` を実行すると、`gh-pages` ブランチへビルド成果物が自動的に配置されます。
+
+これによりGitHub Pagesでアプリケーションを公開できます。

--- a/package.json
+++ b/package.json
@@ -2,15 +2,21 @@
   "name": "bento-order",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"
   },
+  "devDependencies": {
+    "gh-pages": "^6.0.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,8 @@ function App() {
   const [menu, setMenu] = useState([]);
 
   useEffect(() => {
-    fetch('/menu.json')
+    const menuUrl = process.env.PUBLIC_URL + '/menu.json';
+    fetch(menuUrl)
       .then((res) => res.json())
       .then((data) => setMenu(data))
       .catch((err) => console.error('Failed to load menu:', err));


### PR DESCRIPTION
## Summary
- prepare React app for GitHub Pages
- fetch menu using PUBLIC_URL so the path works when deployed
- document deployment steps

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3df75c9c83289dc5f5b963169bcf