### PR TITLE
Add quantity selector and total calculation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,14 +3,29 @@ import './App.css';
 
 function App() {
   const [menu, setMenu] = useState([]);
+  const [quantities, setQuantities] = useState([]);
 
   useEffect(() => {
     const menuUrl = process.env.PUBLIC_URL + '/menu.json';
     fetch(menuUrl)
       .then((res) => res.json())
-      .then((data) => setMenu(data))
+      .then((data) => {
+        setMenu(data);
+        setQuantities(new Array(data.length).fill(0));
+      })
       .catch((err) => console.error('Failed to load menu:', err));
   }, []);
+
+  const handleQuantityChange = (index, value) => {
+    const updated = [...quantities];
+    updated[index] = Number(value);
+    setQuantities(updated);
+  };
+
+  const total = menu.reduce((sum, item, index) => {
+    const qty = quantities[index] || 0;
+    return sum + item.price * qty;
+  }, 0);
 
   return (
     <div className="App">
@@ -20,9 +35,17 @@ function App() {
         {menu.map((item, index) => (
           <li key={index}>
             {item.name} - {item.price}円
+            <input
+              type="number"
+              min="0"
+              aria-label={`${item.name} quantity`}
+              value={quantities[index] || 0}
+              onChange={(e) => handleQuantityChange(index, e.target.value)}
+            />
           </li>
         ))}
       </ul>
+      <h3>合計: {total}円</h3>
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,35 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
 test('renders welcome message', () => {
   render(<App />);
   const header = screen.getByText(/Welcome to Bento Order/i);
   expect(header).toBeInTheDocument();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('calculates total after selecting quantities', async () => {
+  const mockMenu = [
+    { name: 'からあげ弁当', price: 100 },
+    { name: 'のり弁当', price: 200 },
+  ];
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(mockMenu) })
+  );
+
+  render(<App />);
+
+  const karaInput = await screen.findByLabelText('からあげ弁当 quantity');
+  const noriInput = await screen.findByLabelText('のり弁当 quantity');
+
+  await userEvent.clear(karaInput);
+  await userEvent.type(karaInput, '2');
+  await userEvent.clear(noriInput);
+  await userEvent.type(noriInput, '1');
+
+  expect(screen.getByText('合計: 400円')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add quantity selection for each bento item
- compute and display order total
- test the new total price logic

## Testing
- `npm install --silent` *(fails: network access needed)*
- `npm test --silent` *(fails: react-scripts missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e6be331cc8328975e5b76a8e2e155