### PR TITLE
Add reserve button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,13 @@
 .App {
   text-align: center;
   padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.reserve-button {
+  margin-top: auto;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,10 @@ import './App.css';
 function App() {
   const [menu, setMenu] = useState([]);
 
+  const handleReserve = () => {
+    // reservation handling will be implemented later
+  };
+
   useEffect(() => {
     const menuUrl = process.env.PUBLIC_URL + '/menu.json';
     fetch(menuUrl)
@@ -23,6 +27,9 @@ function App() {
           </li>
         ))}
       </ul>
+      <button className="reserve-button" onClick={handleReserve}>
+        予約
+      </button>
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,3 +6,9 @@ test('renders welcome message', () => {
   const header = screen.getByText(/Welcome to Bento Order/i);
   expect(header).toBeInTheDocument();
 });
+
+test('renders reserve button', () => {
+  render(<App />);
+  const button = screen.getByRole('button', { name: '予約' });
+  expect(button).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add bottom reserve button with empty handler
- style button at page bottom
- test for new reserve button

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6c22c9d48328a58d95636f4d0486