### PR TITLE
Add shopping cart panel with adjustable quantities

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,3 +27,32 @@
   width: 2rem;
   height: 2rem;
 }
+
+.add-button {
+  margin-left: 1rem;
+}
+
+.cart-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 250px;
+  height: 100%;
+  background: #f9f9f9;
+  border-left: 1px solid #ccc;
+  padding: 1rem;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.cart-panel ul {
+  list-style: none;
+  padding: 0;
+}
+
+.cart-panel li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,8 @@ import './App.css';
 function App({ initialDate = null }) {
   const [menu, setMenu] = useState([]);
   const [selectedDate, setSelectedDate] = useState(initialDate);
-  const [quantities, setQuantities] = useState({});
+  const [cart, setCart] = useState({});
+  const [showCart, setShowCart] = useState(false);
   const handleReserve = () => {
     // TODO: implement reservation logic
   };
@@ -19,8 +20,16 @@ function App({ initialDate = null }) {
       .catch((err) => console.error('Failed to load menu:', err));
   }, []);
 
-  const changeQuantity = (index, delta) => {
-    setQuantities((prev) => {
+  const addToCart = (index) => {
+    setCart((prev) => {
+      const current = prev[index] || 0;
+      return { ...prev, [index]: current + 1 };
+    });
+    setShowCart(true);
+  };
+
+  const changeCartQuantity = (index, delta) => {
+    setCart((prev) => {
       const current = prev[index] || 0;
       const next = Math.max(current + delta, 0);
       const updated = { ...prev };
@@ -33,10 +42,12 @@ function App({ initialDate = null }) {
     });
   };
 
-  const totalPrice = menu.reduce(
-    (sum, item, i) => sum + (quantities[i] || 0) * (item.price || 0),
-    0
-  );
+  const cartItems = Object.keys(cart);
+
+  const totalPrice = cartItems.reduce((sum, key) => {
+    const i = Number(key);
+    return sum + (cart[i] || 0) * (menu[i]?.price || 0);
+  }, 0);
 
   return (
     <div className="App">
@@ -59,18 +70,37 @@ function App({ initialDate = null }) {
                 <span>
                   {item.name} - {item.price}円
                 </span>
-                <div className="quantity-controls">
-                  <button onClick={() => changeQuantity(index, -1)}>-</button>
-                  <span>{quantities[index] || 0}</span>
-                  <button onClick={() => changeQuantity(index, 1)}>+</button>
-                </div>
+                <button className="add-button" onClick={() => addToCart(index)}>
+                  追加
+                </button>
               </li>
             ))}
           </ul>
-          <p>合計: {totalPrice}円</p>
         </>
       ) : (
         <p>まずは注文したい日を選択してください。</p>
+      )}
+      {showCart && (
+        <div className="cart-panel">
+          <h3>買い物かご</h3>
+          <ul>
+            {cartItems.map((key) => {
+              const i = Number(key);
+              const item = menu[i];
+              return (
+                <li key={key}>
+                  <span>{item.name}</span>
+                  <div className="quantity-controls">
+                    <button onClick={() => changeCartQuantity(i, -1)}>-</button>
+                    <span>{cart[i]}</span>
+                    <button onClick={() => changeCartQuantity(i, 1)}>+</button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <p>合計: {totalPrice}円</p>
+        </div>
       )}
       <button className="reserve-button" onClick={handleReserve}>予約</button>
     </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -46,7 +46,7 @@ test('calculates total price when quantity is increased', async () => {
   });
 
   const addButton = Array.from(container.querySelectorAll('button')).find(
-    (b) => b.textContent.trim() === '+'
+    (b) => b.textContent.trim() === '追加'
   );
 
   expect(addButton).toBeTruthy();


### PR DESCRIPTION
## Summary
- switch menu items to an add-only button
- show shopping cart panel with per-item quantity controls
- adjust tests for new cart behavior

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689330b3ca508328ab38a369d4c10de8