### PR TITLE
Style menu items as modern cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,34 @@
   margin-bottom: 1.5rem;
 }
 
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 0;
+  list-style: none;
+  margin: 1rem 0;
+}
+
+.menu-card {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.menu-card h3 {
+  margin: 0 0 0.5rem;
+}
+
+.menu-card .price {
+  font-weight: bold;
+  margin: 0 0 1rem;
+}
+
 .reserve-button {
   position: fixed;
   bottom: 1rem;
@@ -29,7 +57,7 @@
 }
 
 .add-button {
-  margin-left: 1rem;
+  margin-top: 0.5rem;
 }
 
 .cart-panel {

--- a/src/App.js
+++ b/src/App.js
@@ -64,18 +64,17 @@ function App({ initialDate = null }) {
       {selectedDate ? (
         <>
           <h2>Menu</h2>
-          <ul>
+          <div className="menu-grid">
             {menu.map((item, index) => (
-              <li key={index}>
-                <span>
-                  {item.name} - {item.price}円
-                </span>
+              <div className="menu-card" key={index}>
+                <h3>{item.name}</h3>
+                <p className="price">{item.price}円</p>
                 <button className="add-button" onClick={() => addToCart(index)}>
                   追加
                 </button>
-              </li>
+              </div>
             ))}
-          </ul>
+          </div>
         </>
       ) : (
         <p>まずは注文したい日を選択してください。</p>


### PR DESCRIPTION
## Summary
- Display menu items as cards in a responsive grid
- Add modern card styling and adjust add-to-cart button spacing

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68933421bcd88328819cc323ef25c534